### PR TITLE
fix: fix vite import and broken image url

### DIFF
--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, toRefs } from 'vue'
-import { dia, shapes, elementTools } from '@clientio/rappid';
+import { dia, shapes, elementTools } from '@clientio/rappid/rappid.js';
 
 const props = defineProps({
   msg: String
@@ -25,7 +25,7 @@ onMounted(() => {
         text: msg.value
       },
       image: {
-        xlinkHref: 'https://vuejs.org/images/logo.svg'
+        xlinkHref: 'https://via.placeholder.com/100/0000FF'
       }
     }
   });


### PR DESCRIPTION
### Description
- fix broken import for `@clientio/rappid`
<img width="870" alt="Screenshot 2023-01-23 at 7 51 58" src="https://user-images.githubusercontent.com/42288565/213985535-0b77aa7d-3ae0-42e8-a47d-cbffef4776f2.png">

- fix image URL that doesn't exist anymore (replaced with `https://placeholder.com/` image)